### PR TITLE
Headers

### DIFF
--- a/public/img/.htaccess
+++ b/public/img/.htaccess
@@ -6,5 +6,7 @@
 <FilesMatch "\.(jpg|jpeg|jpe|gif|png|tif|tiff)$">
 	Order Deny,Allow
 	Allow from all
-    Header append Cache-Control "public"
+    <IfModule mod_headers.c>
+        Header append Cache-Control "public"
+    </IfModule>
 </FilesMatch>


### PR DESCRIPTION
I found out that the .htaccess causes a 500 Internal Server Error, if the Module Headers is not enabled. Now its surrounded by an IfModule, so the Error cant occur again.
